### PR TITLE
Bugfix: init agent_interactions variable to None

### DIFF
--- a/src/phantom_eval/__main__.py
+++ b/src/phantom_eval/__main__.py
@@ -105,6 +105,7 @@ async def main(args: argparse.Namespace) -> None:
                 # Run the method and get final responses for the batch
                 # In zeroshot, fewshot, the LLM responds with the final answer in 1 turn only,
                 # so they support batch async inference
+                agent_interactions = None
                 match args.method:
                     case "zeroshot" | "zeroshot-sc" | "fewshot" | "fewshot-sc":
                         questions: list[str] = batch_df_qa_pairs["question"].tolist()


### PR DESCRIPTION
`python -m phantom_eval --method zeroshot ...` was throwing a local variable not found error. This was because `save_preds` was referencing `agent_interactions` that was only assigned locally inside match-case statements. Init `agent_interactions = None` globally then update them locally.