### PR TITLE
Revert "added intrinsic difficulty of different relations "

### DIFF
--- a/src/phantom_wiki/facts/family/constants.py
+++ b/src/phantom_wiki/facts/family/constants.py
@@ -27,7 +27,6 @@ FAMILY_FACT_TEMPLATES = {
 }
 
 FAMILY_FACT_TEMPLATES_PL = {
-    "parent": "The parents of <subject> are",
     "brother": "The brothers of <subject> are",
     "sister": "The sisters of <subject> are",
     "sibling": "<subject>'s siblings are",
@@ -44,7 +43,6 @@ FAMILY_FACT_TEMPLATES_PL = {
 
 # Base rules
 FAMILY_RELATION_EASY = [
-    "parent",
     "sibling",
     "sister",
     "brother",
@@ -109,49 +107,3 @@ FAMILY_RELATION_HARD_PLURALS = [
     "grandDaughters",
     "grandSons",
 ]
-
-"""intrinsic difficulty for different family relations
-For all the predictates that occur in the articles the difficulty is 1.
-For harder predicates the difficulty is incremented by the extra articles that need to be checked to determine it.
-i.e. How many articles need to be retrieved to reach the relation.
-"""
-FAMILY_RELATION_DIFFICULTY = {
-    "parent": 1,
-    "sibling": 1,
-    "sister": 1,
-    "brother": 1,
-    "mother": 1,
-    "father": 1,
-    "child": 1,
-    "son": 1,
-    "daughter": 1,
-    "wife": 1,
-    "husband": 1,
-    "niece": 2,
-    "nephew": 2,
-    "grandparent": 2,
-    "grandmother": 2,
-    "grandfather": 2,
-    "great_aunt": 3,
-    "great_uncle": 3,
-    "grantchild": 2,
-    "granddaughter": 2,
-    "grandson": 2,
-    "great_grandparent": 3,
-    "great_grandmother": 3,
-    "great_grandfather": 3,
-    "great_grandchild": 3,
-    "great_granddaughter": 3,
-    "great_grandson": 3,
-    "second_aunt": 4,
-    "second_uncle": 4,
-    "aunt": 2,
-    "uncle": 2,
-    "cousin": 3,
-    "female_cousin": 3,
-    "male_cousin": 3,
-    "female_second_cousin": 5,
-    "male_second_couin": 5,
-    "female_first_cousin_once_removed": 4,
-    "male_first_cousin_once_removed": 4,
-}


### PR DESCRIPTION
Reverts albertgong1/phantom-wiki#97

some bug occurred with `sample.py` 


```
Saving questions to: inter/questions
Traceback (most recent call last):
  File "/opt/anaconda3/envs/dataset/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/anaconda3/envs/dataset/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/Users/chaowan/Documents/github/phantom-wiki/src/phantom_wiki/__main__.py", line 211, in <module>
    main(args)
  File "/Users/chaowan/Documents/github/phantom-wiki/src/phantom_wiki/__main__.py", line 159, in main
    _, question, query = sample(
  File "/Users/chaowan/Documents/github/phantom-wiki/src/phantom_wiki/facts/sample.py", line 138, in sample
    sample_predicate(FAMILY_RELATION_EASY_PLURALS, match, i, mapping=FAMILY_RELATION_EASY_PL2SG)
  File "/Users/chaowan/Documents/github/phantom-wiki/src/phantom_wiki/facts/sample.py", line 112, in sample_predicate
    query[i] = tmp.replace(match, mapping[choice] if mapping else choice)
KeyError: 'sister_in_laws'
```

possibly related to the in-laws, will check 