### PR TITLE
Switching X/Y order improves time to compute

### DIFF
--- a/src/phantom_wiki/facts/family/rules_base.pl
+++ b/src/phantom_wiki/facts/family/rules_base.pl
@@ -15,9 +15,9 @@ married(X, Y) :-
   parent(Child, Y),
   X \= Y.
 
-sister(Y, X) :-
+sister(X, Y) :-
   sibling(X, Y),
-  female(X).
+  female(Y).
 
 brother(X, Y) :-
   sibling(X, Y),


### PR DESCRIPTION
After some searching with Albert, we figured out that swaping X and Y in the prolog statement makes it signficantly faster.

For example, at 16k individuals, the change makes the querying process go from taking 73.61558604 seconds to around 1 second.