### PR TITLE
Execute db.query() once in get_answer() for speedup

### DIFF
--- a/src/phantom_wiki/__main__.py
+++ b/src/phantom_wiki/__main__.py
@@ -189,14 +189,14 @@ def main(args):
             # TODO: is there a better way to do this?
             # NOTE: we concatenate the clauses in the prolog query in reverse order
             # since prolog executes goals from left to right
-            all_results, final_results = get_answer(query, db, answer, add_intermediate_answers=True)
+            solution_traces, final_results = get_answer(query, db, answer, return_solution_traces=True)
             # make unique and sort in alphabetical order
             question_difficulty = calculate_query_difficulty(query)
             questions.append(
                 {
                     "id": generate_unique_id(),
                     "question": question,
-                    "intermediate_answers": json.dumps(all_results), #NOTE: serialize list of dicts so that it can be saved on HF
+                    "intermediate_answers": json.dumps(solution_traces), # NOTE: serialize list of dicts so that it can be saved on HF
                     "answer": final_results,
                     "prolog": {"query": query, "answer": answer},
                     "template": question_template,
@@ -236,6 +236,8 @@ def main(args):
 if __name__ == "__main__":
     # we combine a base parser with the family generator parser
     # TODO: add parser for other generation components
+    # TODO: change --depth 10 --num-samples 1 --max-tree-size 50 --max-tree-depth 20 to be more informative
+    # i.e. specify which depth corresponds to question depth, family tree depth etc.
     # - attribute
     parser = get_parser(
         parents=[

--- a/src/phantom_wiki/utils/get_answer.py
+++ b/src/phantom_wiki/utils/get_answer.py
@@ -8,7 +8,7 @@ def get_answer(
     query: list[str],
     db: Database,
     answer: str,
-    add_intermediate_answers: bool = False
+    return_solution_traces: bool = False
 ) -> tuple[list[dict[str, str]], list[str]]:
     """Get the answer to a query from the database
 
@@ -18,39 +18,41 @@ def get_answer(
         db (Database): The database to query
         answer (str): The answer to the query as a placeholder
             Example: "Y_3"
-        add_intermediate_answers (bool, optional): Whether to add intermediate answers to the results.
-            Defaults to False.
+        return_solution_traces (bool, optional): Flag to return solution traces (intermediate results).
+            Defaults to False, in which case the returned list is empty.
 
     Returns:
-        intermediate_answers: list[dict[str, str]]
-            A list of dictionaries with the results along the "path" to the final answer
+        solution_traces: list[dict[str, str]]
+            A list of dictionaries with the results along the "path trace" to the final answer
         final_results: list[str] 
             The final results of the entire query
 
     Example:
     ```python
     query = [child(Y_2, Y_3), sister(Elisa, Y_2)]
-    intermediate_answers, final_results = get_answer(query, db, "Y_3", add_intermediate_answers=True)
+    solution_traces, final_results = get_answer(query, db, "Y_3", return_solution_traces=True)
     ```
     outputs `[{"Y_2": "Alice", "Y_3": "Bob"}], ["Bob"]`.
-    Each dictionary in the intermediate_answers list is a sequence of placeholders and values towards a final answer.
-    There can be multiple final answers, and so multiple dictionaries in intermediate_answers.
+    Each dictionary in the solution_traces list is a sequence of placeholders and values towards a final answer.
+    There can be multiple final answers, and so multiple dictionaries in solution_traces.
     """
+    # Evaluate the reversed query
     reversed_query = query[::-1]
-    if add_intermediate_answers:
-        intermediate_answers: list[dict[str, str]] = [
-            {k: decode(v) for k, v in x.items()}
-            for x in db.query(", ".join(reversed_query))
-        ]
-        # intermediate_answers can contain duplicate dictionaries, keep only unique ones
-        # frozenset is used to make the dictionaries hashable, and set to remove duplicates
-        unique_intermediate_answers = set(frozenset(d.items()) for d in intermediate_answers)
-        intermediate_answers = [dict(s) for s in unique_intermediate_answers]
-    else:
-        logging.warning("Skipping intermediate answers")
-        intermediate_answers = []
+    query_result = list(db.query(", ".join(reversed_query)))  # db.query returns a generator, so we convert it to a list
 
-    final_results = [decode(x[answer]) for x in db.query(", ".join(reversed_query))]
+    if return_solution_traces:
+        solution_traces: list[dict[str, str]] = [
+            {k: decode(v) for k, v in x.items()} for x in query_result
+        ]
+        # solution_traces can contain duplicate dictionaries, keep only unique ones
+        # frozenset is used to make the dictionaries hashable, and set to remove duplicates
+        unique_solution_traces = set(frozenset(d.items()) for d in solution_traces)
+        solution_traces = [dict(s) for s in unique_solution_traces]
+    else:
+        logging.warning("Skipping solution traces")
+        solution_traces = []
+
+    final_results = [decode(x[answer]) for x in query_result]
     final_results = sorted(set(final_results))
 
-    return intermediate_answers, final_results
+    return solution_traces, final_results


### PR DESCRIPTION
`get_answer()` needlessly queries the database twice, which is expensive. And change intermediate_answers variable to solution_traces. Column name in dataset output is still "intermediate_answers" to be consistent with published v0.3.