### PR TITLE
Gemini can refuse to answer API call if copyright violation, handle error

### DIFF
--- a/src/phantom_eval/llm.py
+++ b/src/phantom_eval/llm.py
@@ -572,14 +572,24 @@ class GeminiChat(CommonLLMChat):
         return response
 
     def _parse_api_output(self, response: object) -> LLMChatResponse:
+        # Try to get response text. If failed due to any reason, output empty prediction
+        # Example instance why Gemini can fail to return response.text:
+        # "The candidate's [finish_reason](https://ai.google.dev/api/generate-content#finishreason) is 4. Meaning that the model was reciting from copyrighted material."
+        try:
+            pred = response.text
+            error = None
+        except Exception as e:
+            pred = ""
+            error = str(e)
         return LLMChatResponse(
-            pred=response.text,
+            pred=pred,
             usage={
                 "prompt_token_count": response.usage_metadata.prompt_token_count,
                 "response_token_count": response.usage_metadata.candidates_token_count,
                 "total_token_count": response.usage_metadata.total_token_count,
                 "cached_content_token_count": response.usage_metadata.cached_content_token_count,
             },
+            error=error
         )
 
     def _count_tokens(self, messages_api_format: list[dict]) -> int:


### PR DESCRIPTION
New kind of API call error where Gemini does not populate `response.part` because it thinks there's a copyright violation. Add that error to the preds file and avoid crashing the script.