### PR TITLE
Successfully save solution traces to file, solving #191

### DIFF
--- a/src/phantom_wiki/__main__.py
+++ b/src/phantom_wiki/__main__.py
@@ -214,7 +214,7 @@ def main(args):
                 {
                     "id": generate_unique_id(),
                     "question": question,
-                    "intermediate_answers": json.dumps(solution_traces), # NOTE: serialize list of dicts so that it can be saved on HF
+                    "solution_traces": json.dumps(solution_traces), # NOTE: serialize list of dicts so that it can be saved on HF
                     "answer": final_results,
                     "prolog": {"query": query, "answer": answer},
                     "template": question_template,

--- a/src/phantom_wiki/facts/__init__.py
+++ b/src/phantom_wiki/facts/__init__.py
@@ -46,8 +46,6 @@ question_parser.add_argument("--num-sampling-attempts", type=int, default=100,
                                 help="Number of attempts to sample a valid question")
 question_parser.add_argument("--depth", type=int, default=6,
                                 help="Depth of the question template")
-question_parser.add_argument("--add-intermediate-answers", action="store_true",
-                                help="Add intermediate answers to the questions")
 question_parser.add_argument("--hard-mode", action="store_true",
                                 help="Sample from hard relations")
 question_parser.add_argument("--skip-solution-traces", action="store_true",

--- a/src/phantom_wiki/utils/get_answer.py
+++ b/src/phantom_wiki/utils/get_answer.py
@@ -20,7 +20,7 @@ def get_answer(
         db (Database): The database to query
         answer (str): The answer to the query as a placeholder
             Example: "Y_3"
-        skip_solution_traces (bool, optional): Flag to skip solution traces (intermediate results).
+        skip_solution_traces (bool, optional): Flag to skip solution traces, which describe the intermediate steps towards final answer.
             Defaults to False, in which case the returned list is non-empty.
 
     Returns:


### PR DESCRIPTION
The idea is to skip decoding `Variable` type. Previously I was decoding them, and then trying to skip them when trying to JSON dump. That was causing segfaults. By skipping them when we decode bytestrings from prolog, we don't encounter any segfaults for any questions. So solution traces now get added to dataset. Resolves #191.

Created a flag `--skip-solution-traces` to skip adding solution traces to dataset, if doing so takes significant time for large datasets. Note that I haven't measured this, but I can imagine that solution traces can be a bottleneck in the future.