### PR TITLE
Add python dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ There are 2 options:
 
 First, install dependencies and [vLLM](https://github.com/vllm-project/vllm) to match your hardware (GPU, CPU, etc.):
 ```bash
-pip install -r requirements-eval.txt
+pip install phantom-wiki[eval]
 pip install "vllm>=0.6.6"
 ```
+
+If you're installing from source, use `pip install .[eval]`.
 
 Then run evaluation methods (like `zeroshot,fewshot,react,...`) with an LLM like so:
 ```bash

--- a/requirements-eval.txt
+++ b/requirements-eval.txt
@@ -1,9 +1,0 @@
-anthropic
-datasets>=3.1.0
-faiss-cpu>=1.9.0.post1
-google-generativeai
-langchain>=0.3.14
-langchain-community
-langchain-together
-tiktoken
-transformers>=4.47.1


### PR DESCRIPTION
Resolves #58 

- Add minimum versions of necessary dependencies for installing `phantom-wiki`. Update README with install instructions. Now `pip install .` on my mac and G2 correctly install, and I can run `./data/generatev05.sh out 1`. 
- Move dependencies for evaluation to `requirements-eval.txt`, as these are not required for the dataset generation part. Accordingly update README.

Need to remove `openai` and `together` from phantom-wiki dependencies as well, but they are imported in a few files https://github.com/albertgong1/phantom-wiki/issues/58#issuecomment-2585369708. Those files are redundant for phantom-wiki, so a future PR should remove them and `openai,together` from `pyproject.toml`.