### PR TITLE
Fix import issues due to pre-commit

### DIFF
--- a/src/phantom_wiki/__main__.py
+++ b/src/phantom_wiki/__main__.py
@@ -16,18 +16,12 @@ import pandas as pd
 from tqdm import tqdm
 
 from .core.article import get_articles
+from .facts import get_database, question_parser
 
 # phantom wiki functionality
 from .facts.attributes import db_generate_attributes
-from .facts.family import db_generate_family
-from .facts.friends import db_generate_friendships
-
-from .facts import (
-    get_database,
-    question_parser,
-)
-from .facts.family import fam_gen_parser
-from .facts.friends import friend_gen_parser
+from .facts.family import db_generate_family, fam_gen_parser
+from .facts.friends import db_generate_friendships, friend_gen_parser
 from .facts.question_difficulty import calculate_query_difficulty
 from .facts.sample import sample_valid_only
 from .facts.templates import generate_templates

--- a/src/phantom_wiki/core/article.py
+++ b/src/phantom_wiki/core/article.py
@@ -2,7 +2,11 @@ from ..facts import Database
 from ..facts.attributes import get_attribute_facts
 from ..facts.family import FAMILY_RELATION_EASY
 from ..facts.family.constants import FAMILY_FACT_TEMPLATES, FAMILY_FACT_TEMPLATES_PL
-from ..facts.friends.constants import FRIENDSHIP_FACT_TEMPLATES, FRIENDSHIP_FACT_TEMPLATES_PL, FRIENDSHIP_RELATION
+from ..facts.friends.constants import (
+    FRIENDSHIP_FACT_TEMPLATES,
+    FRIENDSHIP_FACT_TEMPLATES_PL,
+    FRIENDSHIP_RELATION,
+)
 from ..utils import decode
 from .constants.article_templates import BASIC_ARTICLE_TEMPLATE
 


### PR DESCRIPTION
The use of precommit in the wiki side ended up breaking some of the import statements.

Pre-commit removed unnecessary imports in files. However, sometimes while a variable is not used in a file it  is used in an upstream file. In other words, say you have `file_1` with variables A, B. If `file_2` imports variable A, B but only uses variable A, then pre-commit would have removed the import for variable B in `file_2`. However, if we have a third file, `file_3`, which uses variable B but obtains it by importing `file_2`, then we have an import error, like we see above.

This merge should resolve this problem by moving the import statement to "upstream file". This includes a couple import statements, all in the `__main__.py` and `article.py` files.




