### PR TITLE
236-qwen-support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -565,6 +565,7 @@ nohup.out
 
 # slurm logs
 *slurm*/
+*logs*/
 
 # cache directory for speeding up evaluation
 cachedir/

--- a/src/phantom_eval/__init__.py
+++ b/src/phantom_eval/__init__.py
@@ -1,7 +1,6 @@
 import argparse
 
 from .agent import SUPPORTED_METHOD_NAMES
-from .llm import SUPPORTED_LLM_NAMES
 
 
 def get_parser() -> argparse.ArgumentParser:
@@ -13,7 +12,7 @@ def get_parser() -> argparse.ArgumentParser:
         default="meta-llama/llama-vision-free",
         help="model name. "
         "NOTE: to add a new model, please submit a PR to the repo with the new model name",
-        choices=SUPPORTED_LLM_NAMES,
+        # choices=SUPPORTED_LLM_NAMES,
     )
     parser.add_argument("--model_path", type=str, default=None, help="Path to the model")
     parser.add_argument(

--- a/src/phantom_eval/llm/__init__.py
+++ b/src/phantom_eval/llm/__init__.py
@@ -12,7 +12,6 @@ SUPPORTED_LLM_NAMES: list[str] = (
     + GeminiChat.SUPPORTED_LLM_NAMES
     + OpenAIChat.SUPPORTED_LLM_NAMES
     + TogetherChat.SUPPORTED_LLM_NAMES
-    + VLLMChat.SUPPORTED_LLM_NAMES
 )
 
 
@@ -30,4 +29,7 @@ def get_llm(model_name: str, model_kwargs: dict) -> LLMChat:
             # NOTE: vLLM supports all models on Hugging Face Hub
             return VLLMChat(model_name=model_name, **model_kwargs)
         case _:
-            raise ValueError(f"Model name {model_name} must be one of {SUPPORTED_LLM_NAMES}.")
+            raise ValueError(
+                f"Model name {model_name} must be one of {SUPPORTED_LLM_NAMES}"
+                " or exist as a repo on HuggingFace."
+            )

--- a/src/phantom_eval/llm/__init__.py
+++ b/src/phantom_eval/llm/__init__.py
@@ -1,3 +1,5 @@
+from huggingface_hub import repo_exists
+
 from phantom_eval.llm.anthropic import AnthropicChat
 from phantom_eval.llm.common import LLMChat
 from phantom_eval.llm.gemini import GeminiChat
@@ -24,7 +26,8 @@ def get_llm(model_name: str, model_kwargs: dict) -> LLMChat:
             return OpenAIChat(model_name=model_name, **model_kwargs)
         case model_name if model_name in TogetherChat.SUPPORTED_LLM_NAMES:
             return TogetherChat(model_name=model_name, **model_kwargs)
-        case model_name if model_name in VLLMChat.SUPPORTED_LLM_NAMES:
+        case model_name if repo_exists(model_name):
+            # NOTE: vLLM supports all models on Hugging Face Hub
             return VLLMChat(model_name=model_name, **model_kwargs)
         case _:
             raise ValueError(f"Model name {model_name} must be one of {SUPPORTED_LLM_NAMES}.")

--- a/src/phantom_eval/llm/common.py
+++ b/src/phantom_eval/llm/common.py
@@ -101,6 +101,7 @@ class LLMChat(abc.ABC):
         self,
         model_name: str,
         model_path: str | None = None,
+        strict_model_name: bool = True,
     ):
         """
         Initialize the LLM chat object.
@@ -109,10 +110,17 @@ class LLMChat(abc.ABC):
             model_name (str): The model name to use.
             model_path (Optional[str]): Local path to the model.
                 Defaults to None.
+            strict_model_name (bool): Whether to check if the model name is supported.
+                Defaults to True.
         """
-        assert (
-            model_name in self.SUPPORTED_LLM_NAMES
-        ), f"Model name {model_name} must be one of {self.SUPPORTED_LLM_NAMES}."
+        if strict_model_name:
+            assert (
+                model_name in self.SUPPORTED_LLM_NAMES
+            ), f"Model name {model_name} must be one of {self.SUPPORTED_LLM_NAMES}."
+        else:
+            logger.warning(
+                f"Model name {model_name} is not in the supported list {self.SUPPORTED_LLM_NAMES}."
+            )
         self.model_name = model_name
         self.model_path = model_path
 
@@ -179,8 +187,9 @@ class CommonLLMChat(LLMChat):
         self,
         model_name: str,
         model_path: str | None = None,
+        strict_model_name: bool = True,
     ):
-        super().__init__(model_name, model_path)
+        super().__init__(model_name, model_path, strict_model_name)
         self.client = None
 
     def _update_rate_limits(self, usage_tier: int) -> None:

--- a/src/phantom_eval/llm/vllm.py
+++ b/src/phantom_eval/llm/vllm.py
@@ -34,8 +34,9 @@ class VLLMChat(CommonLLMChat):
         model_path: str | None = None,
         max_model_len: int | None = None,
         tensor_parallel_size: int | None = None,
-        use_api: bool = True,
+        use_api: bool = False,
         port: int = 8000,
+        **kwargs: dict,
     ):
         """
         Args:
@@ -50,7 +51,7 @@ class VLLMChat(CommonLLMChat):
             port (int): Port number for the vllm server.
                 Defaults to 8000.
         """
-        super().__init__(model_name, model_path)
+        super().__init__(model_name, model_path, strict_model_name=False)
 
         # additional stop token for llama models
         # NOTE: eot = end-of-turn

--- a/src/phantom_eval/llm/vllm.py
+++ b/src/phantom_eval/llm/vllm.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 class VLLMChat(CommonLLMChat):
+    # NOTE: vLLM supports all models on Hugging Face Hub, but these are the ones we have officially tested
     SUPPORTED_LLM_NAMES: list[str] = [
         "meta-llama/llama-3.1-8b-instruct",
         "meta-llama/llama-3.1-70b-instruct",

--- a/src/phantom_eval/prompts.py
+++ b/src/phantom_eval/prompts.py
@@ -1,5 +1,6 @@
 import abc
 
+from huggingface_hub import repo_exists
 from langchain.prompts import PromptTemplate
 
 from phantom_eval import constants, llm
@@ -7,7 +8,6 @@ from phantom_eval.llm.anthropic import AnthropicChat
 from phantom_eval.llm.gemini import GeminiChat
 from phantom_eval.llm.openai import OpenAIChat
 from phantom_eval.llm.together import TogetherChat
-from phantom_eval.llm.vllm import VLLMChat
 
 
 class LLMPrompt(abc.ABC):
@@ -807,7 +807,7 @@ def get_llm_prompt(method: str, model_name: str) -> LLMPrompt:
                     return ReactGeminiPrompt()
                 case model_name if model_name in AnthropicChat.SUPPORTED_LLM_NAMES:
                     return ReactLLMPrompt()
-                case model_name if model_name in VLLMChat.SUPPORTED_LLM_NAMES:
+                case model_name if repo_exists(model_name):
                     return ReactLLMPrompt()
                 case _:
                     raise ValueError(f"Model name {model_name} must be one of {llm.SUPPORTED_LLM_NAMES}.")


### PR DESCRIPTION
1. I removed the strict model name matching for vLLM models (only)
2. This allows us to run arbitrary HF models, such as Qwen.
3. Qwen2.5-7b-instruct zeroshot numbers on depth_20_size_50_seed_1:
|                                            |       EM |   precision |   recall |       f1 |   count |
|:-------------------------------------------|---------:|------------:|---------:|---------:|--------:|
| ('qwen/qwen2.5-7b-instruct', 20, 50, 1, 1) | 0.105882 |    0.271699 | 0.167333 | 0.190833 |     510 |