### PR TITLE
Make package version dynamic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "phantom-wiki"
 description = "On-Demand Datasets for Reasoning and Retrieval Evaluation"
-version = "0.5.0"
+dynamic = ["version"]
 authors = [
     {name="Albert Gong", email="ag2435@cornell.edu"},
     {name="Chao Wan", email="cw862@cornell.edu"},


### PR DESCRIPTION
We will always forget to change the hardcoded version. Previously we use to have dynamic version, reverting to that. Hoping that pip version autopopulates by github release tag.