### PR TITLE
Update pyproject to autopopulate __version__ from git tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools", "wheel", "setuptools-git-versioning"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -50,14 +50,14 @@ tests = [
     "rootutils",
 ]
 docs = [
-  "mkdocs==1.6.0",
-  "mkdocs-material==9.5.31",
-  "mkdocstrings[python,shell]==0.25.2",
-  "mkdocs-gen-files==0.5.0",
-  "mkdocs-literate-nav==0.6.1",
-  "mkdocs-section-index==0.3.9",
-  "mkdocs-git-authors-plugin==0.9.0",
-  "mkdocs-git-revision-date-localized-plugin==1.2.6"
+    "mkdocs==1.6.0",
+    "mkdocs-material==9.5.31",
+    "mkdocstrings[python,shell]==0.25.2",
+    "mkdocs-gen-files==0.5.0",
+    "mkdocs-literate-nav==0.6.1",
+    "mkdocs-section-index==0.3.9",
+    "mkdocs-git-authors-plugin==0.9.0",
+    "mkdocs-git-revision-date-localized-plugin==1.2.6"
 ]
 eval = [
     "anthropic",
@@ -83,6 +83,8 @@ Homepage = "https://github.com/kilian-group/phantom-wiki"
 Issues = "https://github.com/kilian-group/phantom-wiki/issues"
 Repository = "https://github.com/kilian-group/phantom-wiki.git"
 
+[tool.setuptools-git-versioning]
+enabled = true
 
 [tool.autoflake]
 ignore-init-module-imports = true


### PR DESCRIPTION
Previous PR #265 didn't populate pip package version automatically. Let's hope this works.