### PR TITLE
Support for Llama API using the OpenAI compatible server

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,19 @@ conda env config vars set GEMINI_API_KEY=xxxxx
 </details>
 
 <details>
+<summary>Llama API</summary>
+
+1. Create an API key at https://llama.developer.meta.com/api-keys/?team_id=1032428561758393
+2. Set you Llama API key as an environment variable. Or in your conda environment:
+
+```bash
+export LLAMA_API_KEY="xxxx"
+# or
+conda env config vars set LLAMA_API_KEY="xxxxx"
+```
+</details>
+
+<details>
 <summary>OpenAI</summary>
 
 1. Create an API key at https://platform.openai.com/settings/organization/api-keys

--- a/src/phantom_eval/llm/__init__.py
+++ b/src/phantom_eval/llm/__init__.py
@@ -12,6 +12,7 @@ SUPPORTED_LLM_SERVERS = [
     "openai",
     "together",
     "vllm",
+    "llama",
 ]
 
 
@@ -37,5 +38,9 @@ def get_llm(server: str, model_name: str, model_kwargs: dict) -> LLMChat:
             from phantom_eval.llm.vllm import VLLMChat
 
             return VLLMChat(model_name=model_name, **model_kwargs)
+        case "llama":
+            from phantom_eval.llm.llama import LlamaChat
+
+            return LlamaChat(model_name=model_name, **model_kwargs)
         case _:
             raise ValueError(f"Provider {server} not supported.")

--- a/src/phantom_eval/llm/anthropic.py
+++ b/src/phantom_eval/llm/anthropic.py
@@ -47,7 +47,10 @@ class AnthropicChat(CommonLLMChat):
         )
         return response
 
-    def _parse_api_output(self, response: object) -> LLMChatResponse:
+    def _parse_api_output(
+        self, response: object, inf_gen_config: InferenceGenerationConfig | None = None
+    ) -> LLMChatResponse:
+        # NOTE: we don't use inf_gen_config for parsing the output of the anthropic server
         return LLMChatResponse(
             pred=response.content[0].text,
             usage=response.usage.model_dump(),

--- a/src/phantom_eval/llm/common.py
+++ b/src/phantom_eval/llm/common.py
@@ -306,7 +306,7 @@ class CommonLLMChat(LLMChat):
         """
 
     @abc.abstractmethod
-    def _parse_api_output(self, response: object) -> LLMChatResponse:
+    def _parse_api_output(self, response: object, inf_gen_config: InferenceGenerationConfig | None = None) -> LLMChatResponse:
         """
         Parse the response from the API and return the prediction and usage statistics.
         """
@@ -365,7 +365,7 @@ class CommonLLMChat(LLMChat):
             logger.debug(f"{self._display_curr_time()}: Released lock for {conv.uid}")
         # wait for the task to complete
         response = await t
-        parsed_response = self._parse_api_output(response)
+        parsed_response = self._parse_api_output(response, inf_gen_config)
         return parsed_response
 
     async def generate_response(
@@ -390,7 +390,7 @@ class CommonLLMChat(LLMChat):
             def _call_api_wrapper() -> str:
                 messages_api_format: list[dict] = self._convert_conv_to_api_format(conv)
                 response = self._call_api(messages_api_format, inf_gen_config)
-                parsed_response = self._parse_api_output(response)
+                parsed_response = self._parse_api_output(response, inf_gen_config)
                 return parsed_response
 
             return _call_api_wrapper()

--- a/src/phantom_eval/llm/gemini.py
+++ b/src/phantom_eval/llm/gemini.py
@@ -61,7 +61,10 @@ class GeminiChat(CommonLLMChat):
         )
         return response
 
-    def _parse_api_output(self, response: object) -> LLMChatResponse:
+    def _parse_api_output(
+        self, response: object, inf_gen_config: InferenceGenerationConfig | None = None
+    ) -> LLMChatResponse:
+        # NOTE: we don't use inf_gen_config for parsing the output of the gemini server
         # Try to get response text. If failed due to any reason, output empty prediction
         # Example instance why Gemini can fail to return response.text:
         # "The candidate's [finish_reason](https://ai.google.dev/api/generate-content#finishreason) is 4.

--- a/src/phantom_eval/llm/llama.py
+++ b/src/phantom_eval/llm/llama.py
@@ -1,0 +1,63 @@
+import os
+
+import openai
+import tiktoken
+
+from phantom_eval._types import LLMChatResponse
+from phantom_eval.llm.common import CommonLLMChat, InferenceGenerationConfig
+
+
+class LlamaChat(CommonLLMChat):
+    def __init__(
+        self,
+        model_name: str,
+        usage_tier: int = 1,
+        **kwargs,
+    ):
+        super().__init__(model_name, **kwargs)
+        self.client = openai.OpenAI(api_key=os.getenv("LLAMA_API_KEY"), base_url="https://api.llama.com/compat/v1/")
+        self.async_client = openai.AsyncOpenAI(api_key=os.getenv("LLAMA_API_KEY"), base_url="https://api.llama.com/compat/v1/")
+        self.encoding = tiktoken.get_encoding("o200k_base")  # FIXME: what encoding to use for Llama-3.3-70B
+        self._update_rate_limits("llama", model_name, usage_tier)
+
+    def _call_api(
+        self,
+        messages_api_format: list[dict],
+        inf_gen_config: InferenceGenerationConfig,
+        use_async: bool = False,
+    ) -> object:
+        # https://platform.openai.com/docs/api-reference/introduction
+        # https://platform.openai.com/docs/api-reference/chat
+        # https://github.com/openai/openai-python
+        client = self.async_client if use_async else self.client
+        response = client.chat.completions.create(
+            model=self.model_name,
+            messages=messages_api_format,
+            temperature=inf_gen_config.temperature,
+            top_p=inf_gen_config.top_p,
+            max_completion_tokens=inf_gen_config.max_tokens,
+            seed=inf_gen_config.seed,
+            stop=inf_gen_config.stop_sequences,
+            # NOTE: top_k is not supported by OpenAI's API
+            # NOTE: repetition_penalty is not supported by OpenAI's API
+        )
+        return response
+
+    def _parse_api_output(self, response: object) -> LLMChatResponse:
+        return LLMChatResponse(
+            pred=response.choices[0].message.content,
+            usage=response.usage.model_dump(),
+        )
+
+    def _count_tokens(self, messages_api_format: list[dict]) -> int:
+        """
+        NOTE: this only counts the tokens in raw string message,
+        not the tokens in the actual prompt to the model,
+        which may be different depending on the server-side implementation.
+        Compared to the actual token count returned by the API responses, this is a systematic overestimate.
+
+        https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken
+        """
+        texts = [msg["content"][0]["text"] for msg in messages_api_format]
+        num_tokens = len(self.encoding.encode("\n".join(texts)))
+        return num_tokens

--- a/src/phantom_eval/llm/llms_rpm_tpm_config.yaml
+++ b/src/phantom_eval/llm/llms_rpm_tpm_config.yaml
@@ -97,3 +97,23 @@ together:
     usage_tier=2:
       RPM: 1800
       TPM: 250000
+
+# Llama Models
+# https://llama.developer.meta.com/docs/rate-limits
+llama:
+  llama-4-scout-17b-16e-instruct-fp8:
+    usage_tier=1:
+      RPM: 3000
+      TPM: 1000000
+  llama-4-maverick-17b-128e-instruct-fp8:
+    usage_tier=1:
+      RPM: 3000
+      TPM: 1000000
+  llama-3.3-70b-instruct:
+    usage_tier=1:
+      RPM: 3000
+      TPM: 1000000
+  llama-3.3-8b-instruct:
+    usage_tier=1:
+      RPM: 3000
+      TPM: 1000000

--- a/src/phantom_eval/llm/openai.py
+++ b/src/phantom_eval/llm/openai.py
@@ -43,7 +43,10 @@ class OpenAIChat(CommonLLMChat):
         )
         return response
 
-    def _parse_api_output(self, response: object) -> LLMChatResponse:
+    def _parse_api_output(
+        self, response: object, inf_gen_config: InferenceGenerationConfig | None = None
+    ) -> LLMChatResponse:
+        # NOTE: we don't use inf_gen_config for parsing the output of the openai server
         return LLMChatResponse(
             pred=response.choices[0].message.content,
             usage=response.usage.model_dump(),

--- a/src/phantom_eval/llm/together.py
+++ b/src/phantom_eval/llm/together.py
@@ -98,7 +98,9 @@ class TogetherChat(CommonLLMChat):
         )
         return response
 
-    def _parse_api_output(self, response: object) -> LLMChatResponse:
+    def _parse_api_output(
+        self, response: object, inf_gen_config: InferenceGenerationConfig | None = None
+    ) -> LLMChatResponse:
         return LLMChatResponse(
             pred=response.choices[0].message.content,
             usage=response.usage.model_dump(),

--- a/src/phantom_eval/llm/together.py
+++ b/src/phantom_eval/llm/together.py
@@ -101,6 +101,7 @@ class TogetherChat(CommonLLMChat):
     def _parse_api_output(
         self, response: object, inf_gen_config: InferenceGenerationConfig | None = None
     ) -> LLMChatResponse:
+        # NOTE: we don't use inf_gen_config for parsing the output of the together server
         return LLMChatResponse(
             pred=response.choices[0].message.content,
             usage=response.usage.model_dump(),

--- a/src/phantom_eval/llm/vllm.py
+++ b/src/phantom_eval/llm/vllm.py
@@ -108,8 +108,12 @@ class VLLMChat(CommonLLMChat):
                         formatted_messages.append({"role": message.role, "content": text})
         return formatted_messages
 
-    def _parse_api_output(self, response: object) -> LLMChatResponse:
-        """Parse the output of vllm server when using the OpenAI compatible server"""
+    def _parse_api_output(
+        self, response: object, inf_gen_config: InferenceGenerationConfig | None = None
+    ) -> LLMChatResponse:
+        """Parse the output of vllm server when using the OpenAI compatible server
+
+        NOTE: we don't use inf_gen_config for parsing the output of the vllm server"""
         return LLMChatResponse(
             pred=response.choices[0].message.content,
             usage=response.usage.model_dump(),

--- a/tests/phantom_eval/test_llm.py
+++ b/tests/phantom_eval/test_llm.py
@@ -6,6 +6,10 @@ See the README for more information.
 
 import asyncio
 
+import nest_asyncio
+
+nest_asyncio.apply()
+
 from phantom_eval.llm import ContentTextMessage, Conversation, InferenceGenerationConfig, Message, get_llm
 
 EXAMPLE_PROMPT = """
@@ -23,7 +27,7 @@ def _test_llm(server: str, model_name: str):
     """
     Test for synchronous calls
     """
-    response = llm_chat.generate_response(example_conv, inf_gen_config)
+    response = asyncio.run(llm_chat.generate_response(example_conv, inf_gen_config))
     pred = response.pred.strip()
     assert pred == "2", f"Expected 2, got {pred}"
 
@@ -82,3 +86,6 @@ def test_vllm():
     response = llm_chat.generate_response(example_conv)
     pred = response.pred.strip()
     assert pred == "2", f"Expected 2, got {pred}"
+
+def test_llama():
+    _test_llm(server="llama", model_name="Llama-3.3-70B-Instruct")

--- a/tests/phantom_eval/test_llm.py
+++ b/tests/phantom_eval/test_llm.py
@@ -75,7 +75,7 @@ def test_vllm():
 
     NOTE: make sure to run the vllm server before running this test!!!
     ```bash
-    vllm serve meta-llama/llama-3.1-8b-instruct --dtype auto --api-key token-abc123 --tensor_parallel_size 4
+    vllm serve meta-llama/llama-3.1-8b-instruct --dtype auto --api-key token-abc123 --tensor_parallel_size 1
     ```
     """
     llm_chat = get_llm(
@@ -83,9 +83,10 @@ def test_vllm():
         model_name="meta-llama/llama-3.1-8b-instruct",
         model_kwargs=dict(use_api=True),
     )
-    response = llm_chat.generate_response(example_conv)
+    response = asyncio.run(llm_chat.generate_response(example_conv, inf_gen_config))
     pred = response.pred.strip()
     assert pred == "2", f"Expected 2, got {pred}"
+
 
 def test_llama():
     _test_llm(server="llama", model_name="Llama-3.3-70B-Instruct")

--- a/tests/phantom_eval/test_llm_async.py
+++ b/tests/phantom_eval/test_llm_async.py
@@ -61,7 +61,10 @@ class MockChat(CommonLLMChat):
 
         return mock_api_call()
 
-    def _parse_api_output(self, response: object) -> LLMChatResponse:
+    def _parse_api_output(
+        self, response: object, inf_gen_config: InferenceGenerationConfig | None = None
+    ) -> LLMChatResponse:
+        # NOTE: we don't use inf_gen_config for parsing the output of the mock server
         return LLMChatResponse(pred=response, usage={})
 
 


### PR DESCRIPTION
Added support for Llama API. Annoyingly, the Llama API doesn't support stop sequences, so we implement the functionality ourselves in `_parse_api_output`. I modified the CommonLLMChat._parse_api_output abstract method to also take in inf_gen_config, which contains information about the stop sequences:
https://github.com/kilian-group/phantom-wiki/blob/db09faf85f13ca6fb21efc01eedf668e5a775a46/src/phantom_eval/llm/common.py#L309

Let me know if you think of a more elegant solution.