### PR TITLE
Evaluation pipeline for new LLMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ PhantomWiki generates on-demand datasets to evaluate reasoning and retrieval cap
 - [Paper](https://arxiv.org/abs/2502.20377)
 - [Demo](https://github.com/kilian-group/phantom-wiki/blob/main/demo.ipynb)
 
-<center>You can evaluate your own model via vLLM on PhantomWiki with in <a name=#-evaluating-llms-on-phantomwiki>1 command</a>!</center>
+<p align="center">
+We provide a <a name="#-evaluating-llms-on-phantomwiki">single script</a> to evaluate your own model on PhantomWiki via vLLM.
+</p>
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ PhantomWiki generates on-demand datasets to evaluate reasoning and retrieval cap
 - [Demo](https://github.com/kilian-group/phantom-wiki/blob/main/demo.ipynb)
 
 <p align="center">
-We provide a <a name="#-evaluating-llms-on-phantomwiki">single script</a> to evaluate your own model on PhantomWiki via vLLM.
+We provide a <a href="#-evaluating-llms-on-phantomwiki">single script</a> to evaluate your own model on PhantomWiki via vLLM.
 </p>
 
 ## Contents

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ PhantomWiki generates on-demand datasets to evaluate reasoning and retrieval cap
 - [Paper](https://arxiv.org/abs/2502.20377)
 - [Demo](https://github.com/kilian-group/phantom-wiki/blob/main/demo.ipynb)
 
+<center>You can evaluate your own model via vLLM on PhantomWiki with in <a name=#-evaluating-llms-on-phantomwiki>1 command</a>!</center>
+
 ## Contents
 
 - [🚀 Quickstart](#-quickstart)
@@ -137,6 +139,18 @@ pip install phantom-wiki[eval]
 
 If you're installing from source, use `pip install -e ".[eval]"`.
 
+Then run the evaluation script to get F1 scores for your model and PhantomWiki reasoning plots:
+
+```bash
+# You can modify the script to add more flags to phantom_eval command
+./eval/evaluate_with_vllm_on_v1.sh OUTPUT_DIRECTORY MODEL_NAME_OR_PATHS METHODS
+
+# For example, evaluating Qwen/Qwen3-32B, DeepSeek-R1-32B models with Zeroshot, CoT prompt methods and saving in out/ directory,
+./eval/evaluate_with_vllm_on_v1.sh out/ "Qwen/Qwen3-32B deepseek-ai/DeepSeek-R1-Distill-Qwen-32B" "zeroshot cot"
+```
+
+The script creates a leaderboard with F1 scores on the PhantomWiki public datasets, and creates the reasoning plot (F1 vs difficulty) at `out/figures/difficulty-f1.pdf`.
+
 ### Setting up API keys
 
 <details>
@@ -218,27 +232,50 @@ The models and their configs are downloaded directly from HuggingFace and almost
 
 ### Reproducing LLM evaluation results in the paper
 
-> \[!NOTE\]
-> For vLLM inference, make sure to request access for Gemma, Llama 3.1, 3.2, and 3.3 models on HuggingFace before proceeding.
-
 🧪 To generate the predictions from an LLM with a prompting `METHOD`, run the following command:
 
 ```bash
 python -m phantom_eval --method METHOD --server SERVER --model_name MODEL_NAME_OR_PATH --split_list SPLIT_LIST -od OUTPUT_DIRECTORY
 ```
 
+#### Closed-source LLMs through Anthropic, OpenAI, Gemini etc.
+
 We implement lightweight interfaces to Anthropic, OpenAI, Gemini, and Together APIs, which you can select by specifying `SERVER`, e.g. `anthropic`, `openai`, `gemini`, `together` respectively.
-We also implement an interface to `vllm` server, to evaluate local LLMs.
 
 Example usages:
 
 - `METHOD` can be `zeroshot`, `fewshot`, `cot`, `react`, `zeroshot-rag` etc.
 - Evaluate GPT-4o through checkpoint names `--server openai --model_name gpt-4o-2024-11-20` or with name aliases `--server openai --model_name gpt-4o`. We pass on the model name to the API, so any LLM name supported by the API is supported by our interface. Similarly for Anthropic, Gemini, and Together.
-- Evaluate Huggingface LLMs through Model Card name `--server vllm --model_name deepseek-ai/DeepSeek-R1-Distill-Qwen-32B`, or through local weights path `--server vllm --model_name /absolute/path/to/weights/`.
-- Evaluate LoRA weights through Model Card name and path to LoRA `--server vllm --model_name deepseek-ai/DeepSeek-R1-Distill-Qwen-32B --inf_vllm_lora_path /path/to/lora/weights/`.
+
+#### Open-weights LLMs through vLLM
+
+We also implement an interface to `vllm` server to evaluate local LLMs on your GPUs.
+We use the API server mode by default, but offline batch evaluation can be faster for prompt methods `zeroshot`, `fewshot`, and `cot`.
+
+1. **API (online) server mode.** First, serve the LLM manually with `vllm serve MODEL_NAME_OR_PATH` and then run `phantom_eval` with flags `--server vllm`. For example:
+
+```bash
+python -m phantom_eval --method METHOD --server vllm --model_name MODEL_NAME_OR_PATH --split_list SPLIT_LIST -od OUTPUT_DIRECTORY
+```
+
+2. **Offline (batch) server mode.** Run `phantom_eval` with flags `--server vllm --inf_vllm_offline`. For example:
+
+```bash
+python -m phantom_eval --method METHOD --server vllm --inf_vllm_offline --model_name MODEL_NAME_OR_PATH --split_list SPLIT_LIST -od OUTPUT_DIRECTORY
+```
+
+Example usages:
+
+- Evaluate Huggingface LLMs through Model Card name `--server vllm --inf_vllm_offline --model_name deepseek-ai/DeepSeek-R1-Distill-Qwen-32B`, or through local weights path `--server vllm --inf_vllm_offline --model_name /absolute/path/to/weights/`.
+- Evaluate LoRA weights through Model Card name and path to LoRA `--server vllm --inf_vllm_offline --model_name deepseek-ai/DeepSeek-R1-Distill-Qwen-32B --inf_vllm_lora_path /path/to/lora/weights/`.
+
+> \[!NOTE\]
+> For vLLM inference, make sure to request access for Gemma, Llama 3.1, 3.2, and 3.3 models on HuggingFace before proceeding.
 
 > \[!TIP\]
 > To generate a slurm script for clusters at Cornell (g2, empire, aida) with the appropriate GPU allocation, run [`bash eval/create_eval.sh`](https://github.com/kilian-group/phantom-wiki/blob/main/eval/create_eval.sh) script and follow the prompted steps.
+
+#### Generating tables and figures
 
 📊 To generate the tables and figures, run the following command from the root directory, replacing `METHODS` with a space-separated list of prompting techniques e.g. `"zeroshot cot zeroshot-rag cot-rag react"`.
 

--- a/eval/evaluate.sh
+++ b/eval/evaluate.sh
@@ -11,7 +11,7 @@
 source eval/constants.sh
 # Parse command line arguments
 OUTPUT_DIR=$1
-MODEL=$2
+MODEL_LIST=$2
 METHOD_LIST=$3
 
 # Get additional flags passed to the script
@@ -19,18 +19,22 @@ shift 3
 cmd_args=$@
 
 echo "Dataset: $DATASET"
-echo "Model: $MODEL"
+echo "Models: $MODEL_LIST"
 echo "Methods: $METHOD_LIST"
 echo "Additional flags: $cmd_args"
 
 # Figure 1: Reasoning and retrieval heatmaps
-python eval/plot_reasoning_retrieval.py -od $OUTPUT_DIR --dataset $DATASET -m $MODEL $cmd_args
+for model in $MODEL_LIST
+do
+    # TODO make plots for each model
+    python eval/plot_reasoning_retrieval.py -od $OUTPUT_DIR --dataset $DATASET -m $model $cmd_args
+done
 
 # Table 2: F1 scores
-python eval/format_leaderboard.py -od $OUTPUT_DIR --dataset $DATASET --model_list $MODEL --method_list $METHOD_LIST $cmd_args
+python eval/format_leaderboard.py -od $OUTPUT_DIR --dataset $DATASET --model_list $MODEL_LIST --method_list $METHOD_LIST $cmd_args
 
 # Figure 3: F1 scores as a function of difficulty, as measured by reasoning steps
-python eval/plot_reasoning.py -od $OUTPUT_DIR --dataset $DATASET --model_list $MODEL $cmd_args
+python eval/plot_reasoning.py -od $OUTPUT_DIR --dataset $DATASET --model_list $MODEL_LIST $cmd_args
 
 # Figure 4: F1 scores as a function of universe size
-python eval/plot_retrieval.py -od $OUTPUT_DIR --dataset $DATASET --model_list $MODEL $cmd_args
+python eval/plot_retrieval.py -od $OUTPUT_DIR --dataset $DATASET --model_list $MODEL_LIST $cmd_args

--- a/eval/evaluate_icml.sh
+++ b/eval/evaluate_icml.sh
@@ -20,7 +20,7 @@ else
 fi
 
 # Override whichever dataset was specified in constants.sh
-DATASET=mlcore/phantom-wiki-v050
+DATASET=mlcore/phantom-wiki-v1
 echo "Dataset: $DATASET"
 MODEL="meta-llama/llama-3.3-70b-instruct"
 

--- a/eval/evaluate_with_vllm_on_v1.sh
+++ b/eval/evaluate_with_vllm_on_v1.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Script to generate tables and plots for any new LLM
+# Example usage (make sure you are in the repo root directory). Additional flags can be passed to the script after method list
+# ```bash
+# ./eval/evaluate_with_vllm_on_v1.sh OUTPUT_DIRECTORY MODEL_NAME_OR_PATH "zeroshot cot zeroshot-rag cot-rag react"
+# ```
+
+# Load constants
+source eval/constants.sh
+# Parse command line arguments
+OUTPUT_DIR=$1
+MODEL_LIST=$2
+METHOD_LIST=$3
+
+# Get additional flags passed to the script
+shift 3
+plotting_cmd_args=$@
+
+echo "Models: $MODEL_LIST"
+echo "Methods: $METHOD_LIST"
+echo "Additional plotting flags: $plotting_cmd_args"
+
+# Run phantom_eval with vLLM
+for method in $METHOD_LIST
+do
+    # if method contains "zeroshot" or "cot", add the --inf_vllm_offline flag
+    phantom_eval_cmd_args="--server vllm"
+    if [[ $method == *"zeroshot"* ]] || [[ $method == *"cot"* ]]; then
+        phantom_eval_cmd_args+=" --inf_vllm_offline"
+    fi
+
+    for model in $MODEL_LIST
+    do
+        python -m phantom_eval \
+            -od $OUTPUT_DIR \
+            --dataset "kilian-group/phantom-wiki-v1" \
+            --split_list depth_20_size_50_seed_1 depth_20_size_50_seed_2 depth_20_size_50_seed_3 \
+            --model_name $model \
+            --method $method \
+            $phantom_eval_cmd_args \
+
+    done
+done
+
+# Figure 1: Reasoning and retrieval heatmaps
+for model in $MODEL_LIST
+do
+    # TODO make plots for each model
+    python eval/plot_reasoning_retrieval.py -od $OUTPUT_DIR --dataset $DATASET -m $model $plotting_cmd_args
+done
+
+# Table 2: F1 scores
+python eval/format_leaderboard.py -od $OUTPUT_DIR --dataset $DATASET --model_list $MODEL_LIST --method_list $METHOD_LIST $plotting_cmd_args
+
+# Figure 3: F1 scores as a function of difficulty, as measured by reasoning steps
+python eval/plot_reasoning.py -od $OUTPUT_DIR --dataset $DATASET --model_list $MODEL_LIST $plotting_cmd_args
+
+# Figure 4: F1 scores as a function of universe size
+python eval/plot_retrieval.py -od $OUTPUT_DIR --dataset $DATASET --model_list $MODEL_LIST $plotting_cmd_args

--- a/eval/format_leaderboard.py
+++ b/eval/format_leaderboard.py
@@ -162,8 +162,3 @@ for line in lines[2:]:
 print("\n".join(new_lines))
 
 print(tabulate(results, tablefmt="github", headers="keys", showindex=False))
-
-# # save to a csv file
-# scores_dir = os.path.join(output_dir, 'scores')
-# os.makedirs(scores_dir, exist_ok=True)
-# results.to_csv(os.path.join(scores_dir, "scores.csv"))

--- a/eval/plot_reasoning.py
+++ b/eval/plot_reasoning.py
@@ -244,9 +244,7 @@ for metric in METRICS:
         if len(METHOD_LIST) > 1:
             ax.set_title(name, fontsize=plotting_utils.LABEL_FONT_SIZE)
 
-    # Create separate handles for models and methods
-    # We will plot models on the left column and methods on the right column
-    # Having the combination of model and method in the legend is too crowded
+    # Model handles at the bottom of the figure
     model_handles = []
     for model in model_list:
         key = f"{plotting_utils.MODEL_ALIASES.get(model.lower(), model)}"
@@ -259,15 +257,15 @@ for metric in METRICS:
                 linewidth=1,
             )
         )
-    # attach the legend to the entire figure instead of any individual subplot
+    ncol = 1 if len(model_handles) <= 2 else 2
     fig.legend(
         handles=model_handles,
         fontsize=plotting_utils.LEGEND_FONT_SIZE,
         loc="lower center",
-        ncol=2,
+        ncol=ncol,
         handlelength=4,
         frameon=False,  # Remove bounding box around legend
-        bbox_to_anchor=(0.5, 0.0),
+        bbox_to_anchor=(0.5, -0.15),
     )
 
     plt.tight_layout()
@@ -282,6 +280,6 @@ for metric in METRICS:
 
     fig_path = os.path.join(figures_dir, f"{DIFFICULTY}-{metric}.pdf")
     print(f"Saving to {os.path.abspath(fig_path)}")
-    plt.savefig(fig_path)
+    plt.savefig(fig_path, bbox_inches="tight", dpi=300)
 
 # %%

--- a/eval/plot_reasoning_retrieval.py
+++ b/eval/plot_reasoning_retrieval.py
@@ -68,9 +68,14 @@ for metric in METRICS:
         [("cot", "In-Context"), ("cot-rag", "RAG"), ("react", "Agentic")]
     ):
         # get evaluation data from the specified output directory and method subdirectory
-        df = get_evaluation_data(output_dir, method, dataset, from_local)
-        # import pdb; pdb.set_trace()
-        df = df[df[DIFFICULTY] <= MAX_DIFFICULTY]
+        try:
+            df = get_evaluation_data(output_dir, method, dataset, from_local)
+            # import pdb; pdb.set_trace()
+            df = df[df[DIFFICULTY] <= MAX_DIFFICULTY]
+        except ValueError as e:
+            logging.warning(f"Error in loading data for {method}: {e}")
+            continue
+
         print(method)
         print(df[df["_model"] == model].groupby(["_size"])["_data_seed"].agg(lambda x: list(set(x))))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,9 @@ eval = [
     "scipy",
     "tiktoken",
     "together",
-    "transformers>=4.47.1",
+    "transformers>=4.51.0",
     "bm25s[full]",
-    "vllm"
+    "vllm>=0.8.5"
 ]
 
 [project.scripts]

--- a/src/phantom_eval/plotting_utils.py
+++ b/src/phantom_eval/plotting_utils.py
@@ -183,7 +183,7 @@ INCONTEXT_METHODS = [
     "cot",
 ]
 RAG_METHODS = [
-    # "zeroshot-rag",
+    "zeroshot-rag",
     "cot-rag",
     # "selfask",
     # "ircot",


### PR DESCRIPTION
- Update vllm and transformers version requirements to support Qwen3, [see huggingface readme](https://huggingface.co/Qwen/Qwen3-32B#quickstart)
- Add `eval/evaluate_with_vllm_on_v1.sh` that runs `phantom_eval` on a specified (new) LLM and generates leaderboard, reasoning, and retrieval plots. Accordingly fix plot generating scripts to handle new LLMs.
- Update README with `phantom_eval` instructions and new eval script.