### PR TITLE
Filtering out aggregation questions for PW evaluation

### DIFF
--- a/eval/format_leaderboard.py
+++ b/eval/format_leaderboard.py
@@ -30,6 +30,9 @@ parser.add_argument(
     "--model_list", nargs="+", default=plotting_utils.DEFAULT_MODEL_LIST, help="List of models to plot"
 )
 parser.add_argument("--filter_by_depth", default=20, type=int, help="Filter by depth")
+parser.add_argument(
+    "--size_list", nargs="+", default=[50, 500, 5000], help="List of universe sizes to include"
+)
 args = parser.parse_args()
 output_dir = args.output_dir
 method_list = args.method_list
@@ -37,13 +40,13 @@ model_list = args.model_list
 dataset = args.dataset
 from_local = args.from_local
 filter_by_depth = args.filter_by_depth
+size_list = list(map(int, args.size_list))
 METRICS = [
     # 'EM',
     # 'precision',
     # 'recall',
     "f1"
 ]
-SIZE_LIST = [50, 500, 5000]
 
 df_list = []
 for method in method_list:
@@ -80,8 +83,8 @@ df_all = pd.concat(df_list)
 # reset index
 df_all = df_all.reset_index(drop=True)
 
-# only consider universe sizes in SIZE_LIST
-results = df_all[df_all["_size"].isin(SIZE_LIST)]
+# only consider universe sizes in size_list
+results = df_all[df_all["_size"].isin(size_list)]
 # use model aliases
 results["_model"] = results["_model"].apply(lambda x: plotting_utils.MODEL_ALIASES.get(x.lower(), x))
 # create table with models as rows and methods as columns

--- a/src/phantom_eval/__init__.py
+++ b/src/phantom_eval/__init__.py
@@ -138,6 +138,11 @@ def get_parser() -> argparse.ArgumentParser:
         help="List of dataset splits to evaluate",
     )
     parser.add_argument("--from_local", action="store_true", help="Load the dataset from a local folder")
+    parser.add_argument(
+        "--exclude_aggregation_questions",
+        action="store_true",
+        help="If set, the evaluation will skip aggregation questions (e.g., 'How many ...')",
+    )
     parser.add_argument("--batch_size", "-bs", default=10, type=int, help="Batch size (>=1)")
     parser.add_argument(
         "--batch_number",

--- a/src/phantom_eval/__main__.py
+++ b/src/phantom_eval/__main__.py
@@ -158,7 +158,12 @@ async def main(args: argparse.Namespace) -> None:
     for seed in args.inf_seed_list:
         logger.info(f"Running inference for method='{args.method}' with {seed=}")
         for split in args.split_list:
-            dataset = load_data(args.dataset, split, args.from_local)
+            dataset = load_data(
+                args.dataset,
+                split,
+                from_local=args.from_local,
+                exclude_aggregation_questions=args.exclude_aggregation_questions,
+            )
             logger.info(f"Loading dataset='{args.dataset}' :: {split=}")
             df_qa_pairs = pd.DataFrame(dataset["qa_pairs"])
             df_text = pd.DataFrame(dataset["text"])
@@ -354,6 +359,7 @@ def save_preds(
                 "batch_size": batch_size,
                 "batch_number": batch_number,
                 "type": int(qa_sample.type),
+                "difficulty": int(qa_sample.difficulty),
             },
             "inference_params": inf_gen_config.model_dump(),
             "model_kwargs": model_kwargs,

--- a/src/phantom_eval/utils.py
+++ b/src/phantom_eval/utils.py
@@ -12,15 +12,29 @@ from joblib import Memory, expires_after
 #
 from nltk import CFG
 
-from phantom_wiki.facts.templates import QA_GRAMMAR_STRING, generate_templates
+from phantom_wiki.facts.templates import QA_GRAMMAR_STRING, generate_templates, is_aggregation_question
 from phantom_wiki.utils.hf_datasets import PhantomWikiDatasetBuilder
 
 memory = Memory("cachedir")
-grammar = CFG.fromstring(QA_GRAMMAR_STRING)
+
+
+def dataset_entry_is_not_aggregation_question(entry: dict) -> bool:
+    """
+    Check if the question is NOT an aggregation question (e.g., "How many ...").
+
+    First check if the column "is_aggregation_question" exists, if so, use it.
+    Otherwise, use phantom_wiki's implementation of is_aggregation_question.
+    """
+    if "is_aggregation_question" in entry:
+        return not entry["is_aggregation_question"]
+    else:
+        return not is_aggregation_question(entry["question"])
 
 
 @memory.cache(cache_validation_callback=expires_after(hours=4))
-def load_data(dataset: str, split: str, from_local: bool = False) -> dict[str, Dataset]:
+def load_data(
+    dataset: str, split: str, from_local: bool = False, exclude_aggregation_questions: bool = False
+) -> dict[str, Dataset]:
     """Load the phantom-wiki dataset from HuggingFace for a specific split or load from a local folder.
 
     NOTE: Split does not necessarily have to exist on HF. We can dynamically construct
@@ -39,6 +53,8 @@ def load_data(dataset: str, split: str, from_local: bool = False) -> dict[str, D
             if from_local=False: The split of the dataset on HF to load.
             if from_local=True: The subdirectory of the local folder.
         from_local: Whether to load the dataset from a local folder.
+        exclude_aggregation_questions: If set, the returned dataset will not contain aggregation questions
+            (e.g., "How many ...").
 
     Returns:
         A dictionary containing the loaded datasets.
@@ -84,13 +100,17 @@ def load_data(dataset: str, split: str, from_local: bool = False) -> dict[str, D
 
     if split in available_splits:
         logging.info(f"Using split {split} from dataset {dataset}.")
+        qa_pairs = ds_question_answer[split]
+        if exclude_aggregation_questions:
+            qa_pairs = qa_pairs.filter(dataset_entry_is_not_aggregation_question)
         return {
-            "qa_pairs": ds_question_answer[split],
+            "qa_pairs": qa_pairs,
             "text": ds_text_corpus[split],
             "database": ds_database[split],
         }
     else:
         requested_depth, requested_size, requested_seed = _get_params(split)
+        grammar = CFG.fromstring(QA_GRAMMAR_STRING)
         requested_question_templates = [
             question for question, _, _ in generate_templates(grammar, depth=requested_depth)
         ]
@@ -104,6 +124,8 @@ def load_data(dataset: str, split: str, from_local: bool = False) -> dict[str, D
                 qa_pairs = ds_question_answer[s].filter(
                     lambda x: x["template"] in requested_question_templates
                 )
+                if exclude_aggregation_questions:
+                    qa_pairs = qa_pairs.filter(dataset_entry_is_not_aggregation_question)
                 return {
                     "qa_pairs": qa_pairs,
                     # the text corpus remains the same, since it is not generated from the CFG

--- a/src/phantom_wiki/facts/templates.py
+++ b/src/phantom_wiki/facts/templates.py
@@ -64,17 +64,19 @@ QA_GRAMMAR_STRING = """
     AV -> '<attribute_value>'
     N -> '<name>'
     """
-# QA_GRAMMAR_STRING = """
-#     S -> 'Who is' R '?' | 'What is' A '?'
-#     R -> 'the' RN 'of' R_c | 'the person whose' AN 'is' AV
-#     R_c -> R | N
-#     A -> 'the' AN 'of' R
-#     RN -> '<relation>'
-#     RN_p -> '<relation_plural>'
-#     AN -> '<attribute_name>'
-#     AV -> '<attribute_value>'
-#     N -> '<name>'
-#     """
+
+
+def is_aggregation_question(question: str) -> bool:
+    """
+    Returns True if the question is an aggregation question.
+
+    Definition of aggregation question:
+    -----------------------------------
+    1. Starts with `"How many"`
+    -----------------------------------
+    For example, "How many children does John have?" is an aggregation question.
+    """
+    return question.strip().startswith("How many")
 
 
 def generate_templates(grammar: CFG = None, depth=4) -> Iterable:

--- a/src/phantom_wiki/generate_dataset.py
+++ b/src/phantom_wiki/generate_dataset.py
@@ -15,7 +15,7 @@ from .facts.family import db_generate_family
 from .facts.friends import db_generate_friendships
 from .facts.question_difficulty import calculate_query_difficulty
 from .facts.sample import sample_question
-from .facts.templates import generate_templates
+from .facts.templates import generate_templates, is_aggregation_question
 from .utils import blue, generate_unique_id
 from .utils.get_answer import get_answer
 
@@ -268,20 +268,23 @@ def generate_dataset(
 
         for j in range(num_questions_per_type):
             # get the difficulty of the question
-            question_difficulty = calculate_query_difficulty(all_queries[i][j])
+            question = all_questions[i][j]
+            query = all_queries[i][j]
+            question_difficulty = calculate_query_difficulty(query)
 
             questions.append(
                 {
                     "id": generate_unique_id(),
-                    "question": all_questions[i][j],
+                    "question": question,
                     "solution_traces": json.dumps(
                         all_solution_traces[i][j]
                     ),  # NOTE: serialize list of dicts so that it can be saved on HF
                     "answer": all_final_results[i][j],
-                    "prolog": {"query": all_queries[i][j], "answer": answer},
+                    "prolog": {"query": query, "answer": answer},
                     "template": question_template,
                     "type": i,  # this references the template type
                     "difficulty": question_difficulty,
+                    "is_aggregation_question": is_aggregation_question(question),
                 }
             )
             if question_format == "json_by_type":

--- a/tests/phantom_wiki/facts/test_question_template.py
+++ b/tests/phantom_wiki/facts/test_question_template.py
@@ -83,9 +83,7 @@ def test_is_aggregation_question_valid():
     ]
 
     for question in exact_how_many_questions:
-        assert is_aggregation_question(
-            question
-        ), f"Expected True for 'How many' question: {' '.join(question)}"
+        assert is_aggregation_question(question), f"Expected True for 'How many' {question=}"
 
 
 def test_is_aggregation_question_valid_w_whitespace():
@@ -102,9 +100,7 @@ def test_is_aggregation_question_valid_w_whitespace():
     ]
 
     for question in whitespace_how_many_questions:
-        assert is_aggregation_question(
-            question
-        ), f"Expected True for 'How many' question: {' '.join(question)}"
+        assert is_aggregation_question(question), f"Expected True for 'How many' {question=}"
 
 
 def test_is_aggregation_question_invalid():
@@ -122,9 +118,7 @@ def test_is_aggregation_question_invalid():
     ]
 
     for question in invalid_aggregation_questions:
-        assert not is_aggregation_question(
-            question
-        ), f"Expected False for invalid aggregation question: {' '.join(question)}"
+        assert not is_aggregation_question(question), f"Expected False for invalid aggregation {question=}"
 
 
 def test_is_aggregation_question_who_questions():
@@ -139,9 +133,7 @@ def test_is_aggregation_question_who_questions():
     ]
 
     for question in who_is_questions:
-        assert not is_aggregation_question(
-            question
-        ), f"Expected False for 'who is' question: {' '.join(question)}"
+        assert not is_aggregation_question(question), f"Expected False for 'who is' {question=}"
 
 
 def test_is_aggregation_question_whatis_questions():
@@ -154,9 +146,7 @@ def test_is_aggregation_question_whatis_questions():
     ]
 
     for question in what_is_questions:
-        assert not is_aggregation_question(
-            question
-        ), f"Expected False for 'what is' question: {' '.join(question)}"
+        assert not is_aggregation_question(question), f"Expected False for 'what is' {question=}"
 
 
 #

--- a/tests/phantom_wiki/facts/test_question_template.py
+++ b/tests/phantom_wiki/facts/test_question_template.py
@@ -4,7 +4,7 @@ import json
 from phantom_wiki.facts import Database
 
 # phantom wiki functionality
-from phantom_wiki.facts.templates import generate_templates
+from phantom_wiki.facts.templates import generate_templates, is_aggregation_question
 from phantom_wiki.utils import get_parser
 
 # testing utils
@@ -69,6 +69,94 @@ def test_template_depth_subsets():
     assert condensed_templates_depth_6 <= condensed_templates_depth_8
     assert condensed_templates_depth_8 <= condensed_templates_depth_10
     assert condensed_templates_depth_10 <= condensed_templates_depth_20
+
+
+def test_is_aggregation_question_valid():
+    """Test is_aggregation_question with exact "How many" matching."""
+
+    # Test exact "How many" pattern (should return True)
+    exact_how_many_questions = [
+        "How many children does John Doe have?",
+        "How many sons does Alice Doe have?",
+        "How many children does the son of John Doe have?",
+        "How many children does the person whose hobby is birdwatching have?",
+    ]
+
+    for question in exact_how_many_questions:
+        assert is_aggregation_question(
+            question
+        ), f"Expected True for 'How many' question: {' '.join(question)}"
+
+
+def test_is_aggregation_question_valid_w_whitespace():
+    """Test is_aggregation_question with exact "How many" matching with leading/ending whitespace."""
+
+    # Test exact "How many" pattern (should return True)
+    whitespace_how_many_questions = [
+        "   How many children does John Doe have?",
+        "How many children does John Doe have?   ",
+        "  How many children does John Doe have?  ",
+        "\tHow many children does John Doe have?",
+        "How many children does John Doe have?\n",
+        " \t How many children does John Doe have? \n ",
+    ]
+
+    for question in whitespace_how_many_questions:
+        assert is_aggregation_question(
+            question
+        ), f"Expected True for 'How many' question: {' '.join(question)}"
+
+
+def test_is_aggregation_question_invalid():
+    """Test questions with 'How' and 'many' in wrong order or positions or punctuation."""
+
+    # Test wrong order or positions (should return False)
+    invalid_aggregation_questions = [
+        "Many how children does John Doe have?",
+        "How much children does the son of John Doe have?",
+        "How MANY children does the son of John Doe have?",
+        "how many children does the son of John Doe have?",
+        "How are children does the person whose hobby is birdwatching have?",
+        "How big children does the person whose hobby is birdwatching have?",
+        "How?",
+    ]
+
+    for question in invalid_aggregation_questions:
+        assert not is_aggregation_question(
+            question
+        ), f"Expected False for invalid aggregation question: {' '.join(question)}"
+
+
+def test_is_aggregation_question_who_questions():
+    """Test is_aggregation_question with 'who is' questions."""
+
+    # Test 'who is' questions (should return False)
+    who_is_questions = [
+        "Who is the child of John Doe?",
+        "Who is the son of Alice Doe?",
+        "Who is the person whose hobby is birdwatching?",
+        "Who is the person whose age is 30?",
+    ]
+
+    for question in who_is_questions:
+        assert not is_aggregation_question(
+            question
+        ), f"Expected False for 'who is' question: {' '.join(question)}"
+
+
+def test_is_aggregation_question_whatis_questions():
+    """Test is_aggregation_question with 'what is' questions."""
+
+    # Test 'what is' questions (should return False)
+    what_is_questions = [
+        "What is the hobby of John Doe?",
+        "What is the job of son of John Doe?",
+    ]
+
+    for question in what_is_questions:
+        assert not is_aggregation_question(
+            question
+        ), f"Expected False for 'what is' question: {' '.join(question)}"
 
 
 #

--- a/tests/phantom_wiki/test_generate_dataset.py
+++ b/tests/phantom_wiki/test_generate_dataset.py
@@ -1,7 +1,9 @@
+import glob
 import json
 import os
 import shutil
 
+from phantom_wiki.facts.templates import is_aggregation_question
 from phantom_wiki.generate_dataset import generate_dataset
 from tests.phantom_wiki import ARTICLE_EXAMPLE_PATH
 
@@ -10,8 +12,8 @@ def test_generate_dataset():
     generate_dataset(output_dir="test_out", seed=1, easy_mode=True)
 
     # get example article
-    with open(ARTICLE_EXAMPLE_PATH) as f:
-        example_article = f.read()
+    with open(ARTICLE_EXAMPLE_PATH) as fname:
+        example_article = fname.read()
     # test that the articles were generated correctly
     article_dir = os.path.join("test_out", "articles")
 
@@ -43,6 +45,20 @@ def test_generate_dataset():
         )
         assert data[0]["prolog"]["query"] == ["daughter(Y_4, Y_2)", 'job(Y_4, "early years teacher")']
         assert data[0]["answer"] == ["Valentina Wexler"]
+        for entry in data:
+            assert not entry[
+                "is_aggregation_question"
+            ], f"'Who is' questions like {entry['question']} should not marked as aggregation questions"
+
+    # Glob over all type*.json files, and check:
+    # - the number of questions is 10
+    # - the is_aggregation_question field matches is_aggregation_question(question) function
+    for fname in glob.glob(os.path.join(question_dir, "type*.json")):
+        with open(fname) as file:
+            data = json.load(file)
+            assert len(data) == 10
+            for entry in data:
+                assert entry["is_aggregation_question"] == is_aggregation_question(entry["question"])
 
     # clean up test_out directory
     shutil.rmtree("test_out")


### PR DESCRIPTION
- Add column "is_aggregation_question: bool" to generated dataset, using the function `is_aggregation_question(question)` that checks if the `question` starts with `"How many"`.
- Add `--exclude-aggregation-questions` flag to `phantom_eval`.
- Add `"difficulty"` entry to phantom_eval's prediction JSON files.

Additional notes:
- `is_aggregation_question()` is consistent with the current CFG generator, which only generates questions satisfying this property. If/when we expand the CFG to different variants of aggregation questions, we can accordingly change `is_aggregation_question()` implementation.
- LLM evaluation is expensive. Previously we'd evaluate on all questions, then filter out the predictions for aggregation questions. Now, `load_data()` has the option to filter out aggregation questions before sending to the LLM, reducing evaluation time/cost. `load_data()` relies on the dataset's `"is_aggregation_question"` column. For maintaining backward-compatibility to v0.5.0 and v1.0 datasets on HF that don't have this column, `load_data()` falls back to phantom-wiki's `is_aggregation_question()` function. I have tested this backward compatibility by evaluating Qwen LLMs on the HF datasets with flag `--exclude-aggregation-questions`.
- Sometimes I'd read the prediction JSON files and not know the question difficulty without looking up question ID or merging 2 dataframes. For convenience, I added "difficulty" entry.