### PR TITLE
SWI-Prolog Pack Support + CoTAgent parsing improvements

### DIFF
--- a/src/phantom_eval/agents/cot.py
+++ b/src/phantom_eval/agents/cot.py
@@ -91,10 +91,6 @@ class CoTAgent(Agent):
             Message(role="assistant", content=[ContentTextMessage(text=response.pred)])
         )
 
-        # if self.prolog_query:
-        #     response.pred = parse_prolog_query(response.pred)
-        #     return response
-
         # Parse the response to extract the answer
         try:
             if parse_thinking_output:

--- a/src/phantom_eval/agents/cot.py
+++ b/src/phantom_eval/agents/cot.py
@@ -91,9 +91,9 @@ class CoTAgent(Agent):
             Message(role="assistant", content=[ContentTextMessage(text=response.pred)])
         )
 
-        if self.prolog_query:
-            response.pred = parse_prolog_query(response.pred)
-            return response
+        # if self.prolog_query:
+        #     response.pred = parse_prolog_query(response.pred)
+        #     return response
 
         # Parse the response to extract the answer
         try:

--- a/src/phantom_eval/agents/cot.py
+++ b/src/phantom_eval/agents/cot.py
@@ -171,7 +171,8 @@ class CoTAgent(Agent):
         The prediction should be of the form: "... The answer is <answer>." otherwise a ValueError is raised.
         """
         # NOTE: Allow for empty answer instead of throwing an error
-        pattern = r"[tT]he answer is (.*)\.\s*$"
+        # NOTE: .* at the start ensures that we take the last occurrence of the pattern in pred
+        pattern = r".*[tT]he answer is (.*)\.\s*$"
         m = re.search(pattern, pred)
         if m:
             return m.group(1)

--- a/src/phantom_eval/prompts.py
+++ b/src/phantom_eval/prompts.py
@@ -343,6 +343,48 @@ Question: Who is the person whose hobby is audiophile?
 Answer: Based on the evidence, there is no person whose hobby is audiophile. The answer is .
 """
 
+COT_EXAMPLES_EASY_ONE_STEP_PROLOG = f"""\
+Example 1:
+Question: Who is the sister of Aida Wang?
+Answer: Based on the evidence, the sisters of Aida Wang are Barabara Beltran, Vicki Hackworth. The answer is "Barabara Beltran"{constants.answer_sep}"Vicki Hackworth".
+
+Example 2:
+Question: Who is the child of Alvaro Smock?
+Answer: Based on the evidence, the children of Alvaro Smock are Eli Smock, Gene Smock. The answer is "Eli Smock"{constants.answer_sep}"Gene Smock".
+
+Example 3:
+Question: How many friends does Ryan Wang have?
+Answer: Based on the evidence, the friends of Ryan Wang are Shelli Beltran, Stacia Toombs, Virgil Hackworth, Aida Wang. The answer is 4.
+
+Example 4:
+Question: Who is the husband of Lannie Smock?
+Answer: Based on the evidence, the husband of Lannie Smock is Alvaro Smock. The answer is "Alvaro Smock".
+
+Example 5:
+Question: Who is the person whose occupation is biomedical scientist?
+Answer: Based on the evidence, the person whose occupation is biomedical scientist is Lannie Smock. The answer is "Lannie Smock".
+
+Example 6:
+Question: Who is the brother of Aida Wang?
+Answer: Based on the evidence, Aida Wang has no brothers. The answer is .
+
+Example 7:
+Question: Who is the daughter of Alvaro Smock?
+Answer: Based on the evidence, Alvaro Smock has no daughters. The answer is .
+
+Example 8:
+Question: Who is the son of Ryan Wang?
+Answer: Based on the evidence, Ryan Wang has no sons. The answer is .
+
+Example 9:
+Question: Who is the person whose occupation is community education officer?
+Answer: Based on the evidence, there is no person whose occupation is community education officer. The answer is .
+
+Example 10:
+Question: Who is the person whose hobby is audiophile?
+Answer: Based on the evidence, there is no person whose hobby is audiophile. The answer is .
+"""
+
 
 class CoTLLMPrompt(LLMPrompt):
     COT_INSTRUCTION = f"""

--- a/src/phantom_wiki/facts/database.py
+++ b/src/phantom_wiki/facts/database.py
@@ -45,6 +45,7 @@ class Database:
                     logger.debug(f"Attaching pack: {abs_subdir}")
                     # NOTE: the query method returns a generator and won't be evaluated until
                     # converted to a list
+                    # NOTE: see instructions in https://www.swi-prolog.org/pldoc/man?section=pack-install
                     _ = list(self.prolog.query(f'pack_attach("{abs_subdir}", [warning, last])'))
                     _ = list(self.prolog.query(f"use_module(library({d}))."))
 

--- a/src/phantom_wiki/facts/database.py
+++ b/src/phantom_wiki/facts/database.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from multiprocessing import Pool
 
 from pyswip import Prolog
@@ -6,6 +7,8 @@ from tqdm import tqdm
 
 from phantom_wiki.facts.family.constants import PERSON_TYPE
 from phantom_wiki.utils import decode
+
+logger = logging.getLogger(__name__)
 
 SAVE_ALL_CLAUSES_TO_FILE = """
 (save_all_clauses_to_file(File) :-
@@ -17,14 +20,33 @@ SAVE_ALL_CLAUSES_TO_FILE = """
 
 
 class Database:
-    def __init__(self, *rules: str):
+    def __init__(self, *rules: str, pack_dir: str = None):
+        """
+        Initializes a Prolog database.
+
+        Args:
+            rules (list[str], optional): list of Prolog files to consult
+            pack_dir (str, optional): path to a directory containing packs of Prolog files
+
+        """
         self.prolog = Prolog()
-        logging.debug("Consulting rules from:")
+        logger.debug("Consulting rules from:")
         for rule in rules:
-            logging.debug(f"- {rule}")
+            logger.debug(f"- {rule}")
             self.prolog.consult(rule)
         # Add ability to save clauses to a file
         self.prolog.assertz(SAVE_ALL_CLAUSES_TO_FILE)
+
+        self.pack_dir = pack_dir
+        if self.pack_dir:
+            for d in os.listdir(self.pack_dir):
+                if os.path.isdir(os.path.join(self.pack_dir, d)):
+                    abs_subdir = os.path.abspath(os.path.join(self.pack_dir, d))
+                    logger.debug(f"Attaching pack: {abs_subdir}")
+                    # NOTE: the query method returns a generator and won't be evaluated until
+                    # converted to a list
+                    _ = list(self.prolog.query(f'pack_attach("{abs_subdir}", [warning, last])'))
+                    _ = list(self.prolog.query(f"use_module(library({d}))."))
 
     @classmethod
     def from_disk(cls, file: str):
@@ -102,9 +124,9 @@ class Database:
         Args:
             files: paths to Prolog files
         """
-        logging.debug("Consulting files:")
+        logger.debug("Consulting files:")
         for file in files:
-            logging.debug(f"- {file}")
+            logger.debug(f"- {file}")
             self.prolog.consult(file)
 
     def add(self, *facts: str) -> None:
@@ -118,9 +140,9 @@ class Database:
         Args:
             facts: list of Prolog fact strings
         """
-        logging.debug("Adding facts:")
+        logger.debug("Adding facts:")
         for fact in facts:
-            logging.debug(f"- {fact}")
+            logger.debug(f"- {fact}")
             self.prolog.assertz(fact)
 
     def remove(self, *facts: str) -> None:
@@ -134,9 +156,9 @@ class Database:
         Args:
             facts: list of Prolog fact strings
         """
-        logging.debug("Removing facts:")
+        logger.debug("Removing facts:")
         for fact in facts:
-            logging.debug(f"- {fact}")
+            logger.debug(f"- {fact}")
             self.prolog.retractall(fact)
 
     def define(self, *predicates: str) -> None:
@@ -148,9 +170,9 @@ class Database:
         Args:
             predicates: list of term signatures
         """
-        logging.debug("Defining rules:")
+        logger.debug("Defining rules:")
         for predicate in predicates:
-            logging.debug(f"- {predicate}")
+            logger.debug(f"- {predicate}")
             self.prolog.dynamic(predicate)
 
     def save_to_disk(self, file: str) -> None:


### PR DESCRIPTION
1. Add support for SWI-Prolog packs, which are the analog of Python packages in SWI-Prolog
2. Modify CoTAgent.parse_answer to take the last occurence of "The answer is ..." since sometimes the model will say "The answer is..." twice.
3. Modify CoTAgent in Prolog mode. Previously, CoTAgent(prolog_query=True) prompted the model to generate a prolog query. Now Prolog=True means the model only needs to generate the answer as a Prolog literal.