### PR TITLE
Remove FlashRAG fork reference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ eval = [
     "transformers>=4.51.0",
     "bm25s[full]",
     "vllm>=0.8.5",
-    "flashrag-dev @ git+https://github.com/bogoliubon/FlashRAG.git"
+    "flashrag-dev"
 ]
 
 [project.scripts]


### PR DESCRIPTION
Removes the reference to the FlashRAG fork, required to deploy a new version of PhantomWiki on PyPI.